### PR TITLE
Remove hard-coded namespace from alertmanager-matrix-forwarder

### DIFF
--- a/alertmanager-matrix-forwarder/Chart.yaml
+++ b/alertmanager-matrix-forwarder/Chart.yaml
@@ -3,5 +3,5 @@ name: alertmanager-matrix-forwarder
 description: A bot to receive Prometheus Alertmanager webhook events and forward them to chosen rooms.
 icon: https://prometheus.io/assets/favicons/favicon.ico
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "1.0.0"

--- a/alertmanager-matrix-forwarder/templates/deployment.yaml
+++ b/alertmanager-matrix-forwarder/templates/deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "forwarder.fullname" . }}
-  namespace: monitoring
   labels:
     {{- include "forwarder.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
Hello!

This is a tiny PR to remove the hard-coded namespace from the alertmanager-matrix-forwarder deployment template. 
